### PR TITLE
Fix : Missing Permission Callback

### DIFF
--- a/admin/class-link-checker-admin.php
+++ b/admin/class-link-checker-admin.php
@@ -69,7 +69,9 @@ class Link_Checker_Admin {
 					array(
 						'methods'             => 'GET',
 						'callback'            => array( $this, 'api_check' ),
-						'permission_callback' => '__return_true',
+						'permission_callback' => function ( WP_REST_Request $request ) {
+							return current_user_can( 'manage_options' );
+						},
 					)
 				);
 			}
@@ -84,7 +86,9 @@ class Link_Checker_Admin {
 					array(
 						'methods'             => 'GET',
 						'callback'            => array( $this, 'api_fetch' ),
-						'permission_callback' => '__return_true',
+						'permission_callback' => function ( WP_REST_Request $request ) {
+							return current_user_can( 'manage_options' );
+						},
 					)
 				);
 			}
@@ -212,6 +216,11 @@ class Link_Checker_Admin {
 
 		$v = filemtime( plugin_dir_path( __FILE__ ) . 'js/link-checker-admin.js' );
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/link-checker-admin.js', array( 'jquery' ), $v, false );
+		wp_add_inline_script(
+			$this->plugin_name,
+			'const wpRestNonce = ' . wp_json_encode( wp_create_nonce( 'wp_rest' ) ),
+			'before'
+		);
 
 	}
 

--- a/admin/class-link-checker-admin.php
+++ b/admin/class-link-checker-admin.php
@@ -67,8 +67,9 @@ class Link_Checker_Admin {
 					'linkchecker/v1',
 					'/check',
 					array(
-						'methods'  => 'GET',
-						'callback' => array( $this, 'api_check' ),
+						'methods'             => 'GET',
+						'callback'            => array( $this, 'api_check' ),
+						'permission_callback' => '__return_true',
 					)
 				);
 			}
@@ -81,8 +82,9 @@ class Link_Checker_Admin {
 					'linkchecker/v1',
 					'/fetch',
 					array(
-						'methods'  => 'GET',
-						'callback' => array( $this, 'api_fetch' ),
+						'methods'             => 'GET',
+						'callback'            => array( $this, 'api_fetch' ),
+						'permission_callback' => '__return_true',
 					)
 				);
 			}

--- a/admin/js/link-checker-admin.js
+++ b/admin/js/link-checker-admin.js
@@ -1,3 +1,4 @@
+/* global wpRestNonce */
 ( function ( $ ) {
     'use strict';
 
@@ -107,7 +108,13 @@
         // Events. TODO: Move this to VueJS event
         $( document ).on( 'click', '.link-checker__btn-start', function () {
             $( '.link-checker__btn-start' ).attr( 'disabled', 1 );
-            $.ajax( '/wp-json/linkchecker/v1/check' ).done( () => {
+            $.ajax( { 
+                url: '/wp-json/linkchecker/v1/check',
+                method: 'GET',
+                headers: {
+                    'X-WP-Nonce': wpRestNonce,
+                }
+            } ).done( () => {
                 $( '.link-checker__btn-start' ).removeAttr( 'disabled' );
                 // TODO: re-render Vue template
                 // pullLastData();


### PR DESCRIPTION
### Issue
- #14 

### Fixes
- Add `permission_callback => '__return_true'` for public `rest_routes`
